### PR TITLE
A few typos and (I think) clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ sudo apt-get install build-essential qt5-default qt5-qmake qtbase5-dev-tools l
 ## Compile and install
 `````
 $ git clone http://github.com/netblue30/AltEdit
-$ cd alt
+$ cd AltEdit
 $ ./configure --prefix=/usr && make && sudo make install strip
 `````
 

--- a/src/alt/mainwindow.cpp
+++ b/src/alt/mainwindow.cpp
@@ -1170,7 +1170,7 @@ void MainWindow::functionList() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-				     tr("This is an untitled file, you would need to save it firest."));
+				     tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 	// save the current buffer

--- a/src/alt/mainwindow_bookmark.cpp
+++ b/src/alt/mainwindow_bookmark.cpp
@@ -124,7 +124,7 @@ void MainWindow::setBookmark0() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -139,7 +139,7 @@ void MainWindow::setBookmark1() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -154,7 +154,7 @@ void MainWindow::setBookmark2() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -169,7 +169,7 @@ void MainWindow::setBookmark3() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -184,7 +184,7 @@ void MainWindow::setBookmark4() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -199,7 +199,7 @@ void MainWindow::setBookmark5() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -214,7 +214,7 @@ void MainWindow::setBookmark6() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -229,7 +229,7 @@ void MainWindow::setBookmark7() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -244,7 +244,7 @@ void MainWindow::setBookmark8() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 
@@ -259,7 +259,7 @@ void MainWindow::setBookmark9() {
 	QString file = active().bufmgr_->active()->file_;
 	if (file.isEmpty()) {
 		QMessageBox::warning(this, tr("AltEdit"),
-			tr("This is an untitled file, you would need to save it firest."));
+			tr("This is an untitled file, you would need to save it first."));
 		return;
 	}
 


### PR DESCRIPTION
Hey @netblue30 - nice little program you've got here! 😁 This just corrects a few typos and such.

A few things I've noticed on my Arch box (that **aren't** covered in this PR):
install-strip fails:
```
make[2]: Leaving directory '/home/fred/AltEdit/src/diff'
make[1]: Leaving directory '/home/fred/AltEdit/src'
strip src/ne/ne
strip: 'src/ne/ne': No such file
make: *** [Makefile:50: install-strip] Error 1
```


When running `alt` from terminal, it keeps saying
```
Warning: ctags not installed
Warning: bcpp not installed
Warning: astyle not installed
sh: ctags: command not found
```
As far as I can tell, AltEdit runs file without these. Would it be better to tag them as Info instead of Warning?

Cheers!